### PR TITLE
fix maximum call stack size exceeded error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonynichols/classnames",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A utility for joining classNames together",
   "license": "MIT",
   "author": "Anthony Nichols <hi@anthonynichols.me>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export function classNames(...args: ClassNames[]) {
       classes.push(arg);
     }
     else if (isArray(arg)) {
-      classes.push(classNames(arg));
+      classes.push(classNames(...arg));
     }
     else if (isObject(arg)) {
       for (let key in arg) {


### PR DESCRIPTION
Fixes this error when passing in an array as an argument.

```
RangeError: Maximum call stack size exceeded
    at Function.isArray
```

Oops.